### PR TITLE
chore: rearrange shinychat circular import

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,10 +21,13 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import plotnine as p9
 import seaborn as sns
-import shinychat
 from dotenv import load_dotenv
 from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
 from shinyrealtime import realtime_server, realtime_ui
+
+# ImportError circular import
+import shinychat
+
 
 load_dotenv()
 


### PR DESCRIPTION
if you import shinychat before shiny it circular imports


```python
import shinychat
from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
from shinyrealtime import realtime_server, realtime_ui
```

returns

```python
>>> import shinychat
ImportError: cannot import name 'Chat' from partially initialized module 'shinychat' (most likely due to a circular import) (/Users/danielchen/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shinychat/__init__.py)
Cell In[1], line 1
----> 1 import shinychat
Hide Traceback
File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shinychat/__init__.py:1
----> 1 from ._chat import Chat, chat_ui
      2 from ._chat_normalize import message_content, message_content_chunk
      3 from ._markdown_stream import MarkdownStream, output_markdown_stream

File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shinychat/_chat.py:24
     21 from weakref import WeakValueDictionary
     23 from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css
---> 24 from shiny import reactive
     25 from shiny._deprecated import warn_deprecated
     26 from shiny.bookmark import BookmarkState, RestoreState

File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shiny/__init__.py:10
      8 from . import quarto
      9 from . import reactive
---> 10 from . import render
     11 from .session import (
     12     Session,
     13     Inputs,
     14     Outputs,
     15 )
     16 from . import session

File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shiny/render/__init__.py:8
      1 """
      2 Tools for reactively rendering output for the user interface.
      3 """
      5 from . import (  # noqa: F401
      6     transformer,  # pyright: ignore[reportUnusedImport]
      7 )
----> 8 from ._data_frame import (
      9     CellPatch,
     10     CellValue,
     11     DataGrid,
     12     DataTable,
     13     data_frame,
     14 )
     15 from ._data_frame_utils._selection import CellSelection
     16 from ._data_frame_utils._types import (  # noqa: F401
     17     StyleInfo,
     18 )

File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shiny/render/_data_frame.py:11
      7 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Union, cast
      9 from htmltools import Tag
---> 11 from .. import reactive, ui
     12 from .._docstring import add_example
     13 from .._utils import wrap_async

File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shiny/ui/__init__.py:70
     53 from ._bootstrap import (
     54     column,
     55     help_text,
   (...)
     61     row,
     62 )
     63 from ._card import (
     64     CardItem,
     65     card,
   (...)
     68     card_header,
     69 )
---> 70 from ._chat import Chat, chat_ui
     71 from ._download_button import download_button, download_link
     72 from ._include_helpers import include_css, include_js

File ~/git/rstudio/shiny-py/venv/lib/python3.12/site-packages/shiny/ui/_chat.py:1
----> 1 from shinychat import Chat, chat_ui
      2 from shinychat.express import Chat as ChatExpress
      3 from shinychat.types import ChatMessageDict
```